### PR TITLE
Adjust spacing to silence error

### DIFF
--- a/Taskfile.sh
+++ b/Taskfile.sh
@@ -30,7 +30,7 @@ _main() {
         tfiles=("${dir}/.Taskfile" "${dir}/.Taskfile.local")
         for tf in "${tfiles[@]}"; do
             # Skip if the file doesn't exist
-            [ ! -f $tf] && continue
+            [ ! -f $tf ] && continue
             echo "Using: $tf"; source "$tf"
         done
     done


### PR DESCRIPTION
In my environment (MacOS Big Sur 11.5.1, zsh shell) executing `Taskfile.sh` throws a number of errors as it searches for `.Taskfile`s:

```
Using: /Users/.Taskfile
/usr/local/bin/t: line 34: /Users/.Taskfile: No such file or directory
/usr/local/bin/t: line 33: [: missing `]'
```

(That's only one; it continues in this vein until it finds a viable `.Taskfile`.)

The script still functions in that it will still display available tasks in the current `.Taskfile` but a screen full of pointless errors is suboptimal. The addition of a single space as per this PR seems to fix the problem.